### PR TITLE
Add Notepad++ support for `@edit`

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -49,6 +49,8 @@ function edit(path::AbstractString, line::Integer=0)
         cmd = line != 0 ? `$command $path -l $line` : `$command $path`
     elseif startswith(name, "subl") || startswith(name, "atom")
         cmd = line != 0 ? `$command $path:$line` : `$command $path`
+    elseif startswith(name, "notepad++")
+        cmd = line != 0 ? `$command $path -n$line` : `$command $path`
     elseif is_windows() && (name == "start" || name == "open")
         cmd = `cmd /c start /b $path`
         line_unsupported = true


### PR DESCRIPTION
Issue #20366

I don't really know how to do a pull request or use GitHub.
I'm also not sure how to test this.
I did test on my local machine by overwriting `edit()`, then just manually copied changed code into GitHub.
