### PR TITLE
Added normalization checks for isidentifier(::Symbol)

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1541,6 +1541,11 @@ recognize a variable, it uses a limited set of characters (greatly extended by
 Unicode). `isidentifier()` makes it possible to query the parser directly
 whether a symbol contains valid characters.
 
+!!! compat "Julia 1.12"
+    In Julia 1.12 or later, `isidentifier` for `Symbol` arguments also requires the symbol to be
+    Unicode-normalized so that it is equivalent to the result of parsing a valid identifier string
+    into a `Symbol`.
+
 # Examples
 ```jldoctest
 julia> Meta.isidentifier(:x), Meta.isidentifier("1x")

--- a/base/show.jl
+++ b/base/show.jl
@@ -1555,7 +1555,16 @@ function isidentifier(s::AbstractString)
     is_id_start_char(c) || return false
     return all(is_id_char, rest)
 end
-isidentifier(s::Symbol) = isidentifier(string(s))
+
+function isidentifier(s::Symbol)
+    str = string(s)
+    if isidentifier(str)
+        normalized_str = Unicode.normalize(str; compose=true, stable=true, chartransform=Unicode.julia_chartransform)
+        return str == normalized_str
+    else
+        return false
+    end
+end
 
 is_op_suffix_char(c::AbstractChar) = ccall(:jl_op_suffix_char, Cint, (UInt32,), c) != 0
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -2795,3 +2795,12 @@ Base.setindex!(d::NoLengthDict, v, k) = d.dict[k] = v
     @test contains(str, "NoLengthDict")
     @test contains(str, "1 => 2")
 end
+
+# Issue 52641
+@testset "isidentifier normalization" begin
+    @test !Base.isidentifier(Symbol("e\u0301")) # not NFC-normalized
+    @test Base.isidentifier(Symbol("\u00E9"))   # NFC-normalized
+    @test !Base.isidentifier(Symbol("\u00B5"))  # U+00B5 = µ normalized to U+03BC = μ by parser
+    @test Base.isidentifier(Symbol("\u03BC"))   # U+03BC = μ is the normalized form
+    @test repr(Symbol("e\u0301")) == "Symbol(\"e\u0301\")"  # isidentifier affects symbol display
+end


### PR DESCRIPTION
Issue #52641

`Base.isidentifier` function doesn't check for normalization of Symbol arguments, leading to inconsistencies in symbol validation and display.